### PR TITLE
Pacthes CVE-2025-48924 and CVE-2025-22227

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,14 +58,11 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
-        <switcher-client.version>2.3.1</switcher-client.version>
+        <switcher-client.version>2.3.2</switcher-client.version>
         <jsonwebtoken.version>0.12.6</jsonwebtoken.version>
         <joda-time.version>2.14.0</joda-time.version>
         <gson.version>2.13.1</gson.version>
         <springdoc.version>2.8.9</springdoc.version>
-
-        <!-- Patch -->
-        <commons-lang3.version>3.18.0</commons-lang3.version>
 
         <!-- Test-->
         <flapdoodle.embed.mongo.version>4.20.0</flapdoodle.embed.mongo.version>
@@ -299,10 +296,24 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Patches Uncontrolled Recursion [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-10734078]-->
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>${commons-lang3.version}</version>
+                <version>3.18.0</version>
+            </dependency>
+
+            <!-- Patches [Low Severity][https://security.snyk.io/vuln/SNYK-JAVA-IOPROJECTREACTORNETTY-10770514]-->
+            <dependency>
+                <groupId>io.projectreactor.netty</groupId>
+                <artifactId>reactor-netty-http</artifactId>
+                <version>1.2.8</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.projectreactor.netty</groupId>
+                <artifactId>reactor-netty-core</artifactId>
+                <version>1.2.8</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
This pull request updates dependencies in the `pom.xml` file to address security vulnerabilities and ensure compatibility. The most important changes include upgrading the `switcher-client.version`, re-adding and updating `commons-lang3.version` with a security patch, and adding dependencies for `reactor-netty` to address vulnerabilities.

### Dependency updates:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L61-L69): Upgraded `switcher-client.version` from `2.3.1` to `2.3.2` to ensure compatibility with the latest features or fixes.

### Security patches:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R299-R316): Re-added `commons-lang3.version` with an updated version (`3.18.0`) to patch a high-severity uncontrolled recursion vulnerability.
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R299-R316): Added dependencies for `reactor-netty-http` and `reactor-netty-core` (version `1.2.8`) to patch a low-severity vulnerability.