### PR TITLE
Bump Springboot@3.5.5, jsonwebtoken@0.13.0, springdoc@2.8.11, updated API docs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.4</version>
+         <version>3.5.5</version>
     </parent>
 
     <properties>
@@ -59,10 +59,10 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
         <switcher-client.version>2.4.1</switcher-client.version>
-        <jsonwebtoken.version>0.12.7</jsonwebtoken.version>
+        <jsonwebtoken.version>0.13.0</jsonwebtoken.version>
         <joda-time.version>2.14.0</joda-time.version>
         <gson.version>2.13.1</gson.version>
-        <springdoc.version>2.8.9</springdoc.version>
+        <springdoc.version>2.8.11</springdoc.version>
 
         <!-- Test-->
         <flapdoodle.embed.mongo.version>4.21.0</flapdoodle.embed.mongo.version>

--- a/src/main/java/com/switcherapi/ac/config/OpenAPIConfiguration.java
+++ b/src/main/java/com/switcherapi/ac/config/OpenAPIConfiguration.java
@@ -15,7 +15,8 @@ import org.springframework.context.annotation.Configuration;
 public class OpenAPIConfiguration {
 	
 	private static final String SCHEME_NAME = "bearerScheme";
-	private static final String SCHEME = "Bearer";
+	private static final String BEARER_FORMAT = "JWT";
+	private static final String SCHEME = "bearer";
 
 	private final ServiceConfig.Docs docs;
 
@@ -70,9 +71,9 @@ public class OpenAPIConfiguration {
 
 	private SecurityScheme createSecurityScheme() {
 		return new SecurityScheme()
-				.name(SCHEME_NAME)
 				.type(SecurityScheme.Type.HTTP)
-				.scheme(SCHEME);
+				.scheme(SCHEME)
+				.bearerFormat(BEARER_FORMAT);
 	}
     
 }

--- a/src/main/java/com/switcherapi/ac/controller/AdminController.java
+++ b/src/main/java/com/switcherapi/ac/controller/AdminController.java
@@ -5,6 +5,7 @@ import com.switcherapi.ac.model.dto.GitHubAuthDTO;
 import com.switcherapi.ac.service.AccountService;
 import com.switcherapi.ac.service.AdminService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -37,12 +38,14 @@ public class AdminController {
 	@Operation(summary = "Update JWT using your refresh token")
 	@PostMapping(value = "/auth/refresh")
 	public Mono<ResponseEntity<GitHubAuthDTO>> gitHubRefreshAuth(
-			@RequestHeader(HttpHeaders.AUTHORIZATION) String token, @RequestParam String refreshToken) {
+			@Parameter(hidden = true) @RequestHeader(HttpHeaders.AUTHORIZATION) String token,
+			@RequestParam String refreshToken) {
 		return adminService.refreshToken(token, refreshToken).map(ResponseEntity::ok);
 	}
-	
+
 	@PostMapping(value = "/logout")
-	public Mono<ResponseEntity<Object>> logout(@RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
+	public Mono<ResponseEntity<Object>> logout(
+			@Parameter(hidden = true) @RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
 		return adminService.logout(token).map(ResponseEntity::ok);
 	}
 	


### PR DESCRIPTION
This pull request updates dependencies and improves the OpenAPI configuration for JWT authentication. The main focus is on aligning the OpenAPI security scheme with best practices and hiding sensitive header parameters from API documentation.

**Dependency updates:**

* Upgraded Spring Boot to version `3.5.5` in `pom.xml`
* Updated `jsonwebtoken` to `0.13.0` and `springdoc` to `2.8.11` in `pom.xml`

**OpenAPI and API documentation improvements:**

* Changed the OpenAPI security scheme in `OpenAPIConfiguration.java` to use `bearer` as the scheme, explicitly set the bearer format to `JWT`, and removed the custom scheme naming to better align with standard JWT authentication practices [[1]](diffhunk://#diff-6d7a44411a97786473b8bc0d5bac1596bcb10be0841339bd856f8b1f4d72d4c6L18-R19) [[2]](diffhunk://#diff-6d7a44411a97786473b8bc0d5bac1596bcb10be0841339bd856f8b1f4d72d4c6L73-R76)
* Added `@Parameter(hidden = true)` to the `Authorization` header in `AdminController.java` for the `gitHubRefreshAuth` and `logout` endpoints, so the header is hidden from generated API docs [[1]](diffhunk://#diff-d4b6f5cc60fdaeb426feab0e4128213bb4f6f1f8ef827536d09d86ca94b526e4R8) [[2]](diffhunk://#diff-d4b6f5cc60fdaeb426feab0e4128213bb4f6f1f8ef827536d09d86ca94b526e4L40-R48)