### PR TITLE
chore(deps): bump springboot@4.1.0 and deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-         <version>4.0.6</version>
+         <version>4.1.0</version>
     </parent>
 
     <properties>
@@ -65,16 +65,16 @@
         <springdoc.version>3.0.3</springdoc.version>
 
         <!-- Test-->
-        <flapdoodle.embed.mongo.version>4.24.0</flapdoodle.embed.mongo.version>
-        <okhttp.version>5.3.2</okhttp.version>
-        <reactor-test.version>3.8.5</reactor-test.version>
+        <flapdoodle.embed.mongo.version>4.33.0</flapdoodle.embed.mongo.version>
+        <okhttp.version>5.4.0</okhttp.version>
+        <reactor-test.version>3.8.6</reactor-test.version>
 
         <!-- Plugins -->
-        <native-image-plugin.version>1.1.0</native-image-plugin.version>
+        <native-image-plugin.version>1.1.2</native-image-plugin.version>
         <maven-compiler.version>3.15.0</maven-compiler.version>
         <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
         <sonar-maven-plugin.version>5.7.0.6970</sonar-maven-plugin.version>
-        <jacoco.version>0.8.14</jacoco.version>
+        <jacoco.version>0.8.15</jacoco.version>
 
         <!-- Sonar -->
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>


### PR DESCRIPTION
This pull request updates several dependencies and plugins in the `pom.xml` to their latest versions, ensuring the project stays current with important upstream improvements and bug fixes.

Dependency and plugin version upgrades:

* Upgraded the Spring Boot parent version from `4.0.6` to `4.1.0`.
* Updated test dependencies: `flapdoodle.embed.mongo` to `4.33.0`, `okhttp` to `5.4.0`, and `reactor-test` to `3.8.6`.
* Upgraded plugin versions: `native-image-plugin` to `1.1.2` and `jacoco` to `0.8.15`.